### PR TITLE
Expand Polish naming guide with case studies, mythology, and cross-language data

### DIFF
--- a/languages/pl.md
+++ b/languages/pl.md
@@ -4,6 +4,45 @@ Polish naming operates under different phonosemantic rules, morphological patter
 
 ---
 
+## Polish Brand Case Studies
+
+Real-world examples of how Polish companies approach naming:
+
+### Polish names for Polish markets
+
+| Brand | Name meaning | Strategy | Why it works |
+|-------|-------------|----------|-------------|
+| **Żabka** | Little frog (żaba + diminutive -ka) | Animal + diminutive | Warmth, friendliness, ubiquity — 11,000+ convenience stores. The diminutive -ka makes it approachable |
+| **Biedronka** | Ladybug (biedronka = ladybird) | Animal + diminutive | Same pattern as Żabka — cute animal name for mass-market retail. Poland's largest discount chain |
+| **Żubr** | European bison | National symbol | Poland's national animal = instant recognition, strength, pride. Best-selling beer by 2016 |
+| **Żywiec** | From the town Żywiec (from *żywy* = alive) | Geographic + etymological depth | The town name carries "life/vitality" at its root — fitting for beer |
+| **Tyskie** | "From Tychy" (adjectival form) | Pure geographic | Place-based naming for a brewery operating since 1613 |
+| **Wykop** | Dig out / excavation | Calque of Digg.com | Literal Polish translation of the concept. Users "wykopują" (dig out) content |
+| **ZnanyLekarz** | Famous/Known Doctor | Descriptive compound | Clear, functional — works domestically. Rebranded to DocPlanner for international markets |
+
+**Pattern:** Polish domestic brands succeed with animal diminutives (Żabka, Biedronka), national symbols (Żubr), geographic references (Żywiec, Tyskie), and descriptive compounds (ZnanyLekarz).
+
+### International ambitions → English names
+
+| Brand | Origin | Strategy | Why they switched/chose English |
+|-------|--------|----------|---------------------------------|
+| **Allegro** | Originally planned as "Zatoka" (bay, modeled on eBay) — name was taken | Italian musical term (lively/fast) | Universal sound, no pronunciation barriers, positive energy. Italy signals quality in European context |
+| **InPost** | In + Post (postal) | English compound | Clean in both Polish and English. Domestic product "Paczkomat" (paczka + automat) became more recognized than the parent brand in Poland |
+| **Brainly** | Started as **Zadane.pl** (from *zadanie* = homework) | English portmanteau (brain + -ly) | Rebranded for US expansion. Original Polish name was descriptive and untranslatable |
+| **Booksy** | Polish-founded by Stefan Batory | English from day one (book + -sy) | Global-first strategy; first client was US-based |
+| **CD Projekt** | CD (compact disc) + Projekt (Polish spelling of "project") | Hybrid Polish-English | Started as literal description (they distributed CDs). "RED" sub-brand added later for game studio |
+
+**Pattern:** Brands targeting international markets choose English names from the start (Booksy, Brainly) or universal-sounding foreign words (Allegro). Hybrid approaches (CD Projekt) work when the name evolves organically.
+
+### Fintech naming
+
+| Brand | Analysis |
+|-------|----------|
+| **mBank** | Single-letter prefix (m = mobile/modern) + Bank. Minimalist, tech-forward. Consolidated from three brands (MultiBank, BRE Bank, mBank) in 2013 |
+| **BLIK** | Short, sharp, instant-sounding. Evolved from IKO (rebranded because "IKO" sounded too close to "PKO" bank). Germanic root *blik* = shine/flash/gleam. Phonosemantics at work — the /bl/ + /ɪk/ combination feels fast and decisive |
+
+---
+
 ## Phonosemantics — Polish Sound Associations
 
 Polish phonosemantics differ significantly from English. Sounds that feel harsh or aggressive in English are neutral or even warm in Polish because the language is built on consonant clusters.
@@ -104,6 +143,32 @@ Polish has an extremely productive diminutive system — far richer than English
 | **-ość** | Abstract quality | *jasność* (brightness), *szybkość* (speed) |
 | **-ica/-yca** | Feminine agent or instrument | *strażnica* (watchtower) |
 
+### Verb-Derived Nouns
+
+Polish productively creates nouns from verbs — useful for naming tools and products:
+
+| Suffix | What it creates | Examples | Brand potential |
+|--------|----------------|---------|----------------|
+| **-acz** | Agent — "the one that does X" | *gracz* (player), *nadawacz* (transmitter), *kopacz* (digger) | Short, punchy, action-oriented. Good for tools that DO something |
+| **-arka** | Instrument/machine — "the thing that does X" | *drukarka* (printer), *zmywarka* (dishwasher), *wiertarka* (drill) | Excellent for tool/utility naming. Clear mechanical connotation |
+| **-anie/-enie** | Action/process (gerund) | *programowanie* (programming), *czytanie* (reading) | Too long and formal for brand names. Better as category descriptors |
+
+### Compound Adjective Prefixes
+
+| Prefix | Meaning | Connotation | Examples |
+|--------|---------|-------------|---------|
+| **wielko-** | Great, large | Scale, grandeur | *wielkopolski* (Greater Poland), *wielkomiejski* (big-city) |
+| **mało-** | Small, little | Can be dismissive | *małomiasteczkowy* (small-town/provincial) — use carefully |
+| **szybko-** | Fast, quick | Speed, efficiency | *szybkoschnący* (quick-drying), *szybkostrzelny* (rapid-fire) |
+
+### Augmentative -isko/-ysko — Handle With Care
+
+The augmentative suffix -isko/-ysko emphasizes largeness but carries **generally negative connotations** in default register:
+
+- **Often pejorative:** *babsko* (from *baba* — hag), *psisko* (big ugly dog)
+- **Sometimes affectionate:** "Dobre psisko!" (good big doggie!) — tone can reclaim it
+- **For brand naming:** Carries a "big, rough, crude" feel. Potentially useful for tools meant to feel powerful/brute-force, but risky for anything refined. Avoid for consumer products.
+
 ---
 
 ## Cultural Naming Conventions
@@ -135,6 +200,29 @@ Less pillaged than Greek/Norse in tech. Rich source material:
 | **Żywia** | Goddess of life and vitality | Health, growth, living systems |
 | **Światowid** | Four-faced god of war and divination | Monitoring, 360 views, multi-perspective |
 | **Leshy/Leszy** | Forest spirit, shape-shifter | Adaptive systems, transformation |
+| **Dadźbóg** | Solar deity, "the giving god" (*dadź* = give + *bóg* = god). Guided the sun on a chariot, died each evening, reborn each morning | Generosity, distribution, illumination, cyclical renewal |
+| **Mokosz** | Earth goddess, Great Mother. Patron of spinning, weaving, childbirth. The only female deity in the Old Kievan pantheon. Name means "moisture" | Weaving/connecting, domestic economy, creation, networks |
+| **Planetnik** | "Shepherds of the clouds." Weather-controlling spirits who move clouds on long ropes, fight storm demons | Cloud management, orchestration, weather APIs. Literally "cloud shepherd" |
+
+### Slavic Folk Creatures
+
+Less known but phonetically appealing names with metaphorical depth:
+
+| Creature | What it is | Naming potential |
+|----------|-----------|-----------------|
+| **Południca** | Lady Midday — noon demon in white with a sickle. Causes heatstroke but also enforces rest periods. Dual nature: threat + protection | Security/monitoring tools (dual threat-and-protection nature). Scheduling tools (noon timing) |
+| **Strzyga** | Vampire-like demon born with two hearts, two souls, two sets of teeth. One soul passes on at death; the other reanimates | Duality metaphor — dual-process systems, backup/redundancy, split-testing |
+| **Ognik** (from Błędne Ogniki) | Will-o'-wisps that guard forgotten treasures. Lure wanderers with hypnotic lights | Discovery/search tools ("leading you to hidden things"). Short, phonetically appealing name |
+| **Zmora** | Nightmare demon / sleep paralysis spirit. Sits on sleepers' chests | Debugging/error-finding tools (ironic). Dark but distinctive sound |
+| **Boginki** | "Minor goddesses" / nature nymphs. Personifications of wild natural forces | Helper/assistant tools. The "minor goddess" meaning is elegant |
+
+### Seasonal Rituals and Concepts
+
+| Concept | What it is | Naming potential |
+|---------|-----------|-----------------|
+| **Noc Kupały** | Slavic midsummer festival (1,500+ years old). Key: flower wreaths in rivers, jumping over bonfires, searching for the mythical fern flower at midnight (grants treasure-finding) | Discovery, search, renewal. "Kupała" has strong positive associations — courage and finding hidden things |
+| **Dziady** | Ancestor veneration ritual. Name from *dziad* (grandfather/ancestor). Feasts for souls, campfires to guide spirits | Version control, archival, legacy systems. "Grandfathers" = previous versions |
+| **Dożynki** | Harvest festival — cutting the last crops, making a harvest wreath, feast. Still celebrated as a national event | Completion, gathering results, analytics dashboards. "Harvest" = collecting output |
 
 ---
 
@@ -184,7 +272,56 @@ Polish words that cause problems internationally:
 | **trup** | Corpse | English "troop" similarity, morbid meaning |
 | **seks** | Sex | Same meaning, but the spelling looks odd |
 
-**Also check:** Names that look innocent in Polish but mean something unintended in German, Czech, Slovak, or Russian — the languages most likely to encounter a Polish brand name.
+### Czech/Slovak False Friends (highest risk)
+
+These are the most dangerous because Czech and Slovak are closely related to Polish — words look similar but meanings diverge:
+
+| Polish word | Polish meaning | Czech/Slovak meaning | Risk level |
+|-------------|---------------|---------------------|------------|
+| **szukać** | To search | *šukať* (SK) = to f**k | **Critical** — any search-related name is dead in Slovak |
+| **droga** | Road, way | *droga* (CZ) = drug, narcotic | High — negative association |
+| **zachód** | West | *záchod* (CZ) = toilet | Embarrassing |
+| **poprawić** | To improve | *popravit* (CZ) = to execute (kill) | Opposite meaning |
+| **jagoda** | Blueberry | *jahoda* (CZ/SK) = strawberry | Confusion — not dangerous but wrong |
+
+### Ukrainian/Russian False Friends
+
+Relevant due to growing Ukrainian community in Poland:
+
+| Polish word | Polish meaning | Ukrainian/Russian meaning | Risk level |
+|-------------|---------------|--------------------------|------------|
+| **uroda** | Beauty | *уrod* (RU) = freak, monster | **Critical** — direct opposite |
+| **sklep** | Shop, store | *склеп* (UA) = crypt, vault | Morbid |
+| **dywan** | Carpet | *диван* (UA/RU) = sofa, couch | Confusion |
+
+**Rule:** Any name derived from *szukać* (search) or *uroda* (beauty) is immediately disqualified for cross-Slavic markets. Always test Polish names against Czech, Slovak, and Ukrainian before committing.
+
+---
+
+## Polish vs English — When to Use Which
+
+Polish speakers readily accept English in tech contexts, but there's cultural appreciation for clever Polish alternatives.
+
+### How Polish adapts English tech terms
+
+Three patterns, each signaling a different register:
+
+1. **Direct borrowing + Polish verb ending (-ować):** *trollować*, *banować*, *hackować*, *spawnować*. The universal adapter — turns any English word into a Polish verb. Natural and accepted.
+
+2. **Phonetic polonization:** *fejsbuk* (Facebook), *hejtować* (to hate), *czilować* (to chill). The English word respelled to match Polish phonetics. Informal, sometimes ironic.
+
+3. **Native Polish translation (calque):** *oprogramowanie* (software, lit. "that which programs"), *ściągać* (to download, lit. "to pull down"). Shows linguistic craft. Appreciated but less common.
+
+### When to name in Polish vs English
+
+| Context | Language | Examples |
+|---------|----------|---------|
+| Polish-only market, mass consumer | Polish | Żabka, Biedronka, Wykop |
+| Polish market, aspirational positioning | Foreign word (Italian, French, Latin) | Allegro |
+| International ambition from day one | English | Booksy, Brainly, InPost |
+| Dual market (Polish + international) | Separate names per market | ZnanyLekarz (PL) / DocPlanner (international) |
+
+**The calque opportunity:** Wykop (Polish for "dig") worked as a Digg.com equivalent because it's a real Polish word that captures the concept naturally. When a direct translation produces a good word, use it.
 
 ---
 


### PR DESCRIPTION
## Summary

Major expansion of `languages/pl.md` across all 6 research areas from #14.

## What's added

### Polish brand case studies (new section)
- **Domestic brands:** Żabka, Biedronka (animal + diminutive pattern), Żubr (national symbol), Żywiec/Tyskie (geographic), Wykop (calque), ZnanyLekarz (descriptive)
- **International brands:** Allegro (Italian word), InPost/Paczkomat, Brainly (Zadane.pl → English rebrand), Booksy, CD Projekt (hybrid)
- **Fintech:** mBank (minimal prefix), BLIK (Germanic root, phonosemantic analysis)
- Naming patterns extracted across all examples

### Expanded morphology
- Verb-derived noun suffixes: -acz (agent), -arka (instrument/machine), -anie/-enie (gerund)
- Compound adjective prefixes: wielko-, mało-, szybko-
- Augmentative -isko/-ysko analysis (generally negative, use with care)

### Expanded Slavic mythology + folk creatures + festivals
- **Gods:** Dadźbóg (solar/giving), Mokosz (earth/weaving), Planetnik ("cloud shepherds")
- **Folk creatures:** Południca (dual threat/protection), Strzyga (duality), Ognik (discovery), Zmora (debugging), Boginki (helper)
- **Festivals:** Noc Kupały (discovery/renewal), Dziady (ancestry/archival), Dożynki (harvest/completion)

### Czech/Slovak/Ukrainian false friends
- Critical: szukać (search) = vulgar in Slovak, uroda (beauty) = freak in Russian
- High risk: droga (road) = drug in Czech, zachód (west) = toilet in Czech
- Ukrainian: sklep (shop) = crypt, dywan (carpet) = sofa

### Polish vs English naming guidance
- Three English adaptation patterns (-ować verbs, phonetic polonization, calques)
- When-to-use-which table (Polish market vs international vs dual)

Closes #14