### PR TITLE
Add anti-pattern gate before scoring rubric

### DIFF
--- a/evaluation.md
+++ b/evaluation.md
@@ -4,6 +4,14 @@ After filtering candidates through anti-patterns and principles, you need a stru
 
 ---
 
+## Pre-Scoring Gate
+
+Before scoring any candidate on the rubric, run it through the Red Flags Checklist in [anti-patterns.md](anti-patterns.md). Any candidate with two or more "yes" answers is disqualified — do not score it. Only candidates that clear this gate proceed to numerical scoring.
+
+This prevents wasting evaluation effort on names that are dead on arrival.
+
+---
+
 ## Scoring Rubric
 
 Rate each finalist on these criteria. Use a 1-5 scale where:


### PR DESCRIPTION
## Summary

Add a "Pre-Scoring Gate" section to evaluation.md requiring candidates to pass the Red Flags Checklist from anti-patterns.md before numerical scoring begins. Two or more red flags = disqualified, don't score.

Closes #22