### PR TITLE
Set up markdownlint CI for pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,10 @@
+name: Lint Markdown
+on:
+  pull_request:
+    paths: ['**/*.md']
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v19

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,20 @@
+# markdownlint configuration
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+# Disable line length — tables and long descriptions need it
+MD013: false
+
+# Disable no-inline-html — some formatting may need it
+MD033: false
+
+# Disable no-duplicate-heading — files reuse headings across sections
+MD024: false
+
+# Disable first-line-heading — files may start with frontmatter or non-heading text
+MD041: false
+
+# Disable blanks-around-fences — too strict for mixed content
+MD031: false
+
+# Disable commands-show-output — code blocks may show example output
+MD014: false


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that runs markdownlint on PRs touching `.md` files
- Add `.markdownlint.yml` config disabling rules that conflict with the skill's style (line length, inline HTML, duplicate headings, first-line heading)

Closes #121