### PR TITLE
Add link checker CI for pull requests

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,13 @@
+name: Check Links
+on:
+  pull_request:
+    paths: ['**/*.md']
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2
+        with:
+          args: --no-progress --offline '**/*.md'
+          fail: true


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow using lychee to check internal markdown links on PRs. Uses `--offline` to only check relative links (no external URL checking to avoid rate limiting).

Catches broken cross-references when files are renamed or restructured.

Closes #126