### PR TITLE
Improve skill description with more trigger keywords

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: naming
-description: Name products, SaaS, brands, and projects. Metaphor-driven naming process that produces memorable, meaningful names and avoids AI slop.
+description: Name products, SaaS, brands, open source projects, bots, and apps. Use when the user needs to name something, find a brand name, or pick a product name. Metaphor-driven process that produces memorable, meaningful names and avoids AI slop.
 ---
 
 # Naming Skill


### PR DESCRIPTION
## Summary

Expand the SKILL.md description field to include more natural trigger phrases so Claude auto-suggests the skill more reliably:
- Added "open source projects, bots, and apps" to product types
- Added "Use when the user needs to name something, find a brand name, or pick a product name"

Stays under ~200 characters to keep context budget low.

Closes #115