### PR TITLE
Add allowed-tools to frontmatter for availability checks

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: naming
 description: Name products, SaaS, brands, open source projects, bots, and apps. Use when the user needs to name something, find a brand name, or pick a product name. Metaphor-driven process that produces memorable, meaningful names and avoids AI slop.
+allowed-tools: Read, Grep, Glob, Bash(whois *), Bash(curl *), Bash(npm view *), Bash(gh repo view *), WebSearch, WebFetch
 ---
 
 # Naming Skill


### PR DESCRIPTION
## Summary

Add `allowed-tools` to SKILL.md frontmatter granting Claude permission to run availability check commands without prompting on each one:
- `Bash(whois *)`, `Bash(curl *)`, `Bash(npm view *)`, `Bash(gh repo view *)`
- `WebSearch`, `WebFetch` for competitor checks
- `Read`, `Grep`, `Glob` for file access

Without this, Step 5 (Availability Gate) would trigger 30-50 permission prompts for 10 semifinalists with 3-5 checks each.

Closes #111