### PR TITLE
Fix markdownlint config — disable rules conflicting with content style

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -18,3 +18,12 @@ MD031: false
 
 # Disable commands-show-output — code blocks may show example output
 MD014: false
+
+# Disable blanks-around-lists — existing content style uses lists directly after paragraphs
+MD032: false
+
+# Disable blanks-around-headings — existing content uses compact heading style
+MD022: false
+
+# Disable no-trailing-punctuation — headings use colons for style
+MD026: false


### PR DESCRIPTION
## Summary

The lint CI (#140) is failing on all PRs because three rules conflict with the existing content style across all files (127 errors):

- **MD032** (blanks-around-lists) — content uses lists directly after paragraphs throughout
- **MD022** (blanks-around-headings) — compact heading style without blank lines
- **MD026** (no-trailing-punctuation) — headings use colons (e.g., "### Compromise (the name is worth fighting for):")

Disabling these matches the existing style. Fixing 127 pre-existing violations across 14 files is not practical and would touch every file in the repo.