### PR TITLE
Fix all markdownlint errors across existing files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at elo@glacierphonk.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <elo@glacierphonk.com>. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Not looking for: subjective opinions without evidence, AI-generated filler, mark
 
 ## File structure
 
-```
+```text
 SKILL.md                  ← Entry point. Defines the 7-step process.
                              Only change this for process flow updates.
 
@@ -78,7 +78,7 @@ Requirements:
 
 - **Verifiable origin story** — link to a primary source: founder interview, blog post, podcast, company documentation. "I think the name comes from..." is not a case study.
 - **Follow the existing table format:**
-  ```
+  ```markdown
   | **Name** | Product category | Origin story | Why it works |
   ```
 - **"Why it works" must reference specific principles** from the skill — which principles does this name satisfy? What makes the metaphor strong?

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ git clone https://github.com/glacierphonk/naming.git ~/.claude/skills/naming
 
 In Claude Code:
 
-```
+```text
 /naming
 ```
 

--- a/brand-architecture.md
+++ b/brand-architecture.md
@@ -122,7 +122,7 @@ When you're creating multiple products under one parent, establishing a naming c
 
 For technical products (bots, APIs, CLI tools), the username/handle convention creates family connection:
 
-```
+```text
 Product name    Handle/Username         Repo name
 ─────────────   ──────────────────────  ─────────────
 Sentry          @sentry                 getsentry/sentry

--- a/cultural-references.md
+++ b/cultural-references.md
@@ -164,12 +164,13 @@ The best cultural reference names work on multiple levels simultaneously:
 **Level 2 — Surface meaning:** The word communicates something even without knowing the reference
 **Level 3 — Cultural depth:** Knowing the reference adds a layer of meaning that rewards discovery
 
-**Example: Bluetooth**
+#### Example: Bluetooth
+
 - Level 1: Two syllables, hard consonants, memorable sound
 - Level 2: "Blue" + "tooth" — distinctive, visual
 - Level 3: Harald Bluetooth united warring factions → technology unites different protocols
 
-**Example: Kafka**
+#### Example: Kafka
 - Level 1: Two syllables, hard K opening, distinctive sound
 - Level 2: Sounds technical, feels like it could be a German engineering term
 - Level 3: Franz Kafka's bureaucratic labyrinths → complex distributed data systems

--- a/evaluation.md
+++ b/evaluation.md
@@ -50,7 +50,7 @@ Rate each finalist on these criteria. Use a 1-5 scale where:
 
 ### Scoring Template
 
-```
+```text
 NAME: _______________
 
 CORE (high weight):
@@ -83,36 +83,36 @@ Maximum possible score: 100 (all 5s). In practice, anything above 75 is strong. 
 Names live in sentences, not in isolation. Test every finalist in these contexts:
 
 ### Introduction
-> "Have you tried ___?"
-> "We just launched ___."
-> "I've been using ___ for a month."
+> "Have you tried `___`?"
+> "We just launched `___`."
+> "I've been using `___` for a month."
 
 Does the name sound natural in casual recommendation?
 
 ### Explanation
-> "We built ___ to solve [problem]."
-> "___ is a [category] that [does what]."
+> "We built `___` to solve [problem]."
+> "`___` is a [category] that [does what]."
 
 Does the name sit comfortably next to its description, or does it feel disconnected?
 
 ### Daily Use
-> "Check the ___ dashboard."
-> "The ___ API is down."
-> "___ just sent an alert."
-> "Let me push this to ___."
+> "Check the `___` dashboard."
+> "The `___` API is down."
+> "`___` just sent an alert."
+> "Let me push this to `___`."
 
 Does the name work as a noun in technical conversation?
 
 ### Marketing
-> "___ — [tagline]"
-> "Get started with ___ in 5 minutes."
-> "Why teams switch to ___."
+> "`___` — [tagline]"
+> "Get started with `___` in 5 minutes."
+> "Why teams switch to `___`."
 
 Does the name work in headlines and calls to action?
 
 ### Word of Mouth
-> "You should try this thing called ___."
-> "Our team switched to ___ last quarter."
+> "You should try this thing called `___`."
+> "Our team switched to `___` last quarter."
 
 This is the most important test. Would someone actually say this name in conversation to a colleague? If the name feels awkward spoken aloud, word-of-mouth growth is crippled.
 
@@ -122,7 +122,7 @@ This is the most important test. Would someone actually say this name in convers
 
 When comparing finalists, use this format:
 
-```
+```text
 ┌─────────────┬──────────┬──────────┬──────────┐
 │ Criterion   │ Name A   │ Name B   │ Name C   │
 ├─────────────┼──────────┼──────────┼──────────┤
@@ -178,7 +178,7 @@ If two or more names score within 5 points of each other, use these tiebreakers 
 
 When presenting finalists to stakeholders or making a final decision, use this structure:
 
-```
+```text
 FINALIST: [Name]
 
 Origin: [15-second story — why it's called this]

--- a/language-rules.md
+++ b/language-rules.md
@@ -93,7 +93,7 @@ Before committing to a foreign word, verify it doesn't carry unfortunate meaning
 
 Always register the ASCII-stripped version of the name as the primary domain and handle. Use the diacriticked version as a redirect or display name:
 
-```
+```text
 Primary: kuznia.com / @kuznia
 Display: Kuźnia
 ```

--- a/metaphor-mapping.md
+++ b/metaphor-mapping.md
@@ -177,7 +177,7 @@ The richest names often come from unexpected territory combinations:
 
 Use this for your own product:
 
-```
+```text
 PRODUCT: _______________
 CORE FUNCTION (one sentence): _______________
 

--- a/phonosemantics.md
+++ b/phonosemantics.md
@@ -177,6 +177,6 @@ When you have a shortlist of name candidates, run this sound check:
 2. **Match dominant sounds to product character.** Do they align?
 3. **Check the vowel weight.** Front (light/fast) vs back (heavy/powerful) — does it match?
 4. **Listen to the ending.** Does it stop cleanly or trail off? Which serves the name better?
-5. **Try it in a sentence.** "Check the ___ dashboard." "We switched to ___." Does the rhythm work in natural speech?
+5. **Try it in a sentence.** "Check the `___` dashboard." "We switched to `___`." Does the rhythm work in natural speech?
 
 Sound alignment is a tiebreaker, not a dealbreaker. A name with a great metaphor and slightly mismatched sounds will always beat a phonetically perfect name with no story.


### PR DESCRIPTION
## Summary

Fix 24 markdownlint errors across 9 files so the lint CI passes cleanly.

## Fixes by rule

- **MD040** (fenced-code-language): Added `text` or `markdown` language tags to all untagged code blocks in brand-architecture.md, CONTRIBUTING.md, evaluation.md, language-rules.md, metaphor-mapping.md, README.md
- **MD034** (no-bare-urls): Wrapped email in angle brackets in CODE_OF_CONDUCT.md
- **MD036** (no-emphasis-as-heading): Converted `**Example: Bluetooth**` and `**Example: Kafka**` to `#### Example:` headings in cultural-references.md
- **MD037** (no-space-in-emphasis): Wrapped `___` name placeholders in backticks across evaluation.md and phonosemantics.md to prevent false emphasis detection

No content changes — only formatting fixes.