### PR TITLE
Add languages/INDEX.md — single source of truth for available languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,7 @@ The 7-step process and 14 reference files are the depth layer. For a quick namin
 | `evaluation.md` | Scoring rubric, comparison framework, decision checklist |
 | `language-rules.md` | Working with foreign words — pronunciation, diacritics, transliteration, exoticism trap |
 | `scripts/check-availability.sh` | Bundled availability checker for domains, npm, GitHub, PyPI, Telegram, etc. |
-| `languages/pl.md` | Polish — phonosemantics, word formation, Slavic mythology, cultural conventions |
-| `languages/pt-PT.md` | European Portuguese — vowel reduction, maritime cultural territory, diacritics |
-| `languages/pt-BR.md` | Brazilian Portuguese — open vowels, diminutives, Tupi-Guarani, regional variation |
+| `languages/INDEX.md` | Language-specific naming guides — see [index](languages/INDEX.md) for available languages (Polish, Portuguese, and more) |
 
 New language files welcome — see [CONTRIBUTING.md](CONTRIBUTING.md#adding-a-language-file) for the template and required sections.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -61,7 +61,7 @@ Load these references as needed:
 - [cultural-references.md](cultural-references.md) — using mythology, literature, science
 - [brand-architecture.md](brand-architecture.md) — if naming within a brand family
 - [language-rules.md](language-rules.md) — when using foreign words or non-English source languages. Covers pronunciation accessibility, cross-language meaning checks, diacritics, transliteration, and the exoticism trap
-- [languages/\<locale\>.md](languages/) — if the naming brief targets a non-English language or multilingual audience. Load the relevant locale file(s) and use its phonosemantic rules, word formation patterns, and cultural conventions instead of (or alongside) the English defaults
+- [languages/INDEX.md](languages/INDEX.md) — if the naming brief targets a non-English language or multilingual audience. Check the index for available locale files, load the relevant one(s), and use its phonosemantic rules, word formation patterns, and cultural conventions instead of the English defaults
 
 ### Step 4: Filter
 
@@ -109,7 +109,7 @@ Pass only the platforms relevant to the naming brief. Run it for each semifinali
 Run whichever of these the naming brief requires:
 
 | Platform | How to check |
-|----------|-------------|
+| -------- | ----------- |
 | **npm** | Bash: `npm view [name] 2>&1` — "not found" = available |
 | **PyPI** | Bash: `curl -s -o /dev/null -w "%{http_code}" https://pypi.org/project/[name]/` — 404 = available |
 | **GitHub org** | Bash: `curl -s -o /dev/null -w "%{http_code}" https://github.com/[name]` — 404 = available |
@@ -159,7 +159,7 @@ Don't keep pushing weak names forward. Looping back to an earlier step produces 
 ## Reference Files
 
 | File | When to load |
-|------|-------------|
+| ---- | ----------- |
 | [principles.md](principles.md) | When generating or evaluating names — the core theory |
 | [phonosemantics.md](phonosemantics.md) | When sound-matching matters for the brief |
 | [anti-patterns.md](anti-patterns.md) | When filtering candidates |
@@ -170,9 +170,7 @@ Don't keep pushing weak names forward. Looping back to an earlier step produces 
 | [availability.md](availability.md) | When checking platform availability |
 | [case-studies.md](case-studies.md) | When studying real-world naming examples |
 | [evaluation.md](evaluation.md) | When scoring and comparing finalists |
-| [languages/pl.md](languages/pl.md) | When naming for a Polish audience |
-| [languages/pt-PT.md](languages/pt-PT.md) | When naming for a European Portuguese audience |
-| [languages/pt-BR.md](languages/pt-BR.md) | When naming for a Brazilian Portuguese audience |
+| [languages/INDEX.md](languages/INDEX.md) | When naming for a non-English audience — see index for available languages |
 
 ## Key Rules
 

--- a/languages/INDEX.md
+++ b/languages/INDEX.md
@@ -1,0 +1,19 @@
+# Available Language Guides
+
+Load the relevant file when the naming brief targets a non-English language or multilingual audience. Each file covers phonosemantics, word formation, cultural conventions, anti-patterns, and cross-language pitfalls for that language.
+
+Use these **instead of** (not alongside) the English-centric `phonosemantics.md` for sound-meaning associations. `principles.md` and `anti-patterns.md` still apply universally.
+
+## Languages
+
+| File | Language | Key features |
+| ---- | -------- | ------------ |
+| [pl.md](pl.md) | Polish | Consonant clusters, sibilant system, Slavic mythology, diminutives, case studies (Allegro, BLIK, Żabka) |
+| [pt-PT.md](pt-PT.md) | European Portuguese | Vowel reduction, maritime cultural territory, diacritics strategy, understated elegance |
+| [pt-BR.md](pt-BR.md) | Brazilian Portuguese | Open vowels, diminutive system, Tupi-Guarani vocabulary, regional variation, musical rhythm |
+
+## Adding a new language
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md#adding-a-language-file) for the required sections and template. Use `pl.md` as the structural reference.
+
+File naming: `<ISO 639-1 code>.md` (e.g., `de.md`, `ja.md`). Use region codes only when regional variation warrants separate files (e.g., `pt-PT.md` vs `pt-BR.md`).


### PR DESCRIPTION
## Summary

- Create `languages/INDEX.md` listing all available language files with descriptions
- Replace per-file rows in SKILL.md reference table with single index reference
- Replace per-file rows in README.md files table with single index reference
- Update SKILL.md Step 3 to reference index instead of individual files
- Fix pre-existing MD060 table separator spacing in SKILL.md

Adding a new language now requires updating one file (INDEX.md) instead of three (SKILL.md, README.md, CONTRIBUTING.md).

Closes #181