### PR TITLE
Create industries/ directory structure and wire into skill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,24 @@ File naming: `languages/<ISO 639-1 code>.md` (e.g., `de.md`, `ja.md`, `fr.md`). 
 
 **Quality bar:** Write from knowledge of the language and culture, not from a quick Wikipedia skim. If you're not confident about a section, mark it with `<!-- TODO: needs native speaker review -->` and we'll find a reviewer.
 
+## Adding an industry file
+
+Industry files live in `industries/` and cover naming constraints for specific niches. Each file needs these sections:
+
+| Section | What to cover |
+| ------- | ------------- |
+| **Platform constraints** | Character limits, slug formats, store/registry requirements |
+| **Audience expectations** | What sounds premium, trustworthy, or appropriate in this industry |
+| **Naming conventions** | Existing patterns and which are saturated |
+| **Trademark / regulatory** | Industry-specific IP or regulatory naming rules |
+| **Case studies** | 3-5 real names analyzed — what works and why |
+| **Anti-patterns** | What constitutes slop in this specific industry |
+| **Territory map** | Metaphor territories especially relevant to this industry |
+
+File naming: `industries/<industry>.md` (e.g., `saas.md`, `fintech.md`, `developer-tools.md`). Lowercase, hyphens for multi-word names.
+
+After creating the file, add it to `industries/INDEX.md`.
+
 ## Adding case studies
 
 Case studies go in `case-studies.md`, organized by naming technique (Metaphor, Common Word, Compound, Invented, Cultural Reference).

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ The 7-step process and 14 reference files are the depth layer. For a quick namin
 | `language-rules.md` | Working with foreign words — pronunciation, diacritics, transliteration, exoticism trap |
 | `scripts/check-availability.sh` | Bundled availability checker for domains, npm, GitHub, PyPI, Telegram, etc. |
 | `languages/INDEX.md` | Language-specific naming guides — see [index](languages/INDEX.md) for available languages (Polish, Portuguese, and more) |
+| `industries/INDEX.md` | Industry-specific naming guides — see [index](industries/INDEX.md) for available industries |
 
-New language files welcome — see [CONTRIBUTING.md](CONTRIBUTING.md#adding-a-language-file) for the template and required sections.
+New language and industry files welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for templates and required sections.
 
 ## Philosophy
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -29,6 +29,8 @@ Before generating ANY names, establish context. Ask the user:
 
 Don't skip this. A naming brief prevents wasted exploration.
 
+**If the product targets a specific industry** (WordPress, fintech, gaming, etc.), check [industries/INDEX.md](industries/INDEX.md) for an industry-specific guide. Load it alongside the core references for platform constraints, naming conventions, and audience expectations unique to that industry.
+
 ### Step 2: Metaphor Exploration
 
 Don't brainstorm names yet. Brainstorm **metaphors and conceptual territories**.
@@ -171,6 +173,7 @@ Don't keep pushing weak names forward. Looping back to an earlier step produces 
 | [case-studies.md](case-studies.md) | When studying real-world naming examples |
 | [evaluation.md](evaluation.md) | When scoring and comparing finalists |
 | [languages/INDEX.md](languages/INDEX.md) | When naming for a non-English audience — see index for available languages |
+| [industries/INDEX.md](industries/INDEX.md) | When naming for a specific industry — see index for available guides |
 
 ## Key Rules
 

--- a/industries/INDEX.md
+++ b/industries/INDEX.md
@@ -1,0 +1,13 @@
+# Available Industry Guides
+
+Load the relevant file when the naming brief identifies a specific industry or niche. Each file covers platform constraints, audience expectations, naming conventions, case studies, anti-patterns, and metaphor territories for that industry.
+
+These are **supplementary** — load alongside the core skill files (principles.md, anti-patterns.md, etc.), not instead of them.
+
+## Industries
+
+No industry files yet. See [open issues](https://github.com/glacierphonk/naming/issues?q=label%3Aindustry) for industries being worked on.
+
+## Adding an industry file
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md#adding-an-industry-file) for required sections, file naming conventions, and the contribution workflow.


### PR DESCRIPTION
## Summary

Set up the `industries/` directory for niche-specific naming guides, mirroring the `languages/` pattern.

- **industries/INDEX.md** — template listing required sections per industry file
- **SKILL.md** — conditional note in Step 1 to load industry guides, added to Reference Files table
- **README.md** — added industries/INDEX.md to Files table, consolidated language rows to index
- **CONTRIBUTING.md** — added "Adding an industry file" section with required sections table

Industry files (saas.md, fintech.md, telegram.md, etc.) can now be contributed following the template.

Closes #180