### PR TITLE
Fix WordPress plugin slug availability check

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -118,7 +118,7 @@ Run whichever of these the naming brief requires:
 | **GitHub repo** | Bash: `gh repo view [org]/[name] 2>&1` — "not found" = available |
 | **crates.io** | Bash: `curl -s -o /dev/null -w "%{http_code}" https://crates.io/api/v1/crates/[name]` — 404 = available |
 | **RubyGems** | Bash: `curl -s -o /dev/null -w "%{http_code}" https://rubygems.org/api/v1/gems/[name].json` — 404 = available |
-| **WP plugin slug** | Bash: `curl -s -o /dev/null -w "%{http_code}" https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=[name]` — check response for "null" = available |
+| **WP plugin slug** | Bash: `curl -s "https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=[name]"` — `"Plugin not found"` in response = available |
 | **Telegram** | Bash: `curl -s -o /dev/null -w "%{http_code}" https://t.me/[name]` — 404 = available |
 | **App stores** | WebSearch: `"[name]" site:apps.apple.com` or `"[name]" site:play.google.com` |
 | **Social handles** | WebSearch: `site:x.com/[name]`, `site:instagram.com/[name]` |

--- a/scripts/check-availability.sh
+++ b/scripts/check-availability.sh
@@ -85,7 +85,7 @@ for platform in "${PLATFORMS[@]}"; do
       ;;
     wp)
       result=$(curl -s "https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=${NAME}" 2>/dev/null || echo "error")
-      if [ "$result" = "null" ] || [ "$result" = "false" ]; then
+      if echo "$result" | grep -qi "not found"; then
         ok "WP plugin: ${NAME}"
       else
         taken "WP plugin: ${NAME}"


### PR DESCRIPTION
## Summary

- Fix `check-availability.sh` WP plugin check — was comparing against `"null"`/`"false"` but the API returns `{"error":"Plugin not found."}`, causing 100% false positives
- Update SKILL.md Step 5 table to document the correct API response format and curl invocation

## Test plan

- [x] `bash scripts/check-availability.sh akismet wp` → TAKEN
- [x] `bash scripts/check-availability.sh zzz-nonexistent-test-plugin-12345 wp` → AVAILABLE
- [x] `markdownlint-cli2 'SKILL.md'` → 0 errors

Fixes #205, fixes #206.