### PR TITLE
docs: add platform-brief alignment reminder to step 5

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -83,7 +83,7 @@ Load [availability.md](availability.md) for the full checking workflow and decis
 
 **What to check is determined by the naming brief (Step 1, question 6).** The user told you which platforms matter. Use that answer to decide which checks are mandatory vs. nice-to-have. Refer to the "Availability Decision Framework" table in availability.md to prioritize.
 
-**Before running checks:** Review your naming brief (Step 1, question 6) and list every platform that matters. Map each to the script's platform argument. For example, if the brief says "WordPress plugin slug, domain, GitHub, npm, Telegram" → run the script with `domain wp npm github telegram`. Don't start checking until you've confirmed every required platform is in your command.
+**Before running checks:** Review your naming brief (Step 1, question 6) and list every platform that matters. Map each to the script's platform argument. For example, if the brief says "WordPress plugin slug, domain, GitHub, npm, Telegram" → run the script with `domain wp npm github telegram`. **Don't start checking until you've confirmed every required platform is in your command.**
 
 #### Required actions for EVERY semifinalist:
 


### PR DESCRIPTION
added a reminder to step 5 about mapping the naming brief platforms to the script arguments. it's easy to forget a platform when running the checks (like forgetting wp even though the brief requires it).

the reminder tells users to explicitly list every platform from the brief and map them to the script args before running checks. emphasized the "don't start checking" part to make it stand out.

let me know if the wording works for you!