### PR TITLE
Add tagline/descriptor generation guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -170,6 +170,7 @@ This is the first time the user sees any name candidates. Present top 3-5 candid
 - Why it works (which principles it satisfies)
 - **Availability status** (which platforms are confirmed available, which need workarounds)
 - Any risks or trade-offs
+- Tagline suggestions (see [taglines.md](taglines.md) for guidance)
 
 Recommend the user sit with finalists for 24 hours before deciding.
 
@@ -201,6 +202,7 @@ Don't keep pushing weak names forward. Looping back to an earlier step produces 
 | [languages/INDEX.md](languages/INDEX.md) | When naming for a non-English audience — see index for available languages |
 | [industries/INDEX.md](industries/INDEX.md) | When naming for a specific industry — see index for available guides |
 | [open-source.md](open-source.md) | When naming an open source project — CLI, registry, and community constraints |
+| [taglines.md](taglines.md) | When crafting taglines for finalists |
 
 ## Key Rules
 

--- a/taglines.md
+++ b/taglines.md
@@ -1,0 +1,147 @@
+# Taglines — The Name's Other Half
+
+A name and tagline work as a pair. The name provides the metaphor and memorability; the tagline provides the clarity and context. A great name with a bad tagline undermines both.
+
+---
+
+## What a Tagline Does
+
+The tagline answers the question the name deliberately leaves open: **"What does this thing actually do?"**
+
+The name captures attention. The tagline converts that attention into understanding.
+
+| Name | Tagline | Why the pair works |
+| ---- | ------- | ------------------ |
+| **Stripe** | "Payment infrastructure for the internet" | Name is abstract; tagline is concrete and specific |
+| **Sentry** | "Application monitoring for developers" | Name plants the metaphor; tagline names the audience |
+| **Notion** | "Your connected workspace" | Name is soft and open; tagline defines the product space |
+| **Linear** | "The issue tracking tool you'll enjoy using" | Name implies simplicity; tagline promises an experience |
+| **Vercel** | "Develop. Preview. Ship." | Name is invented; tagline is three concrete verbs |
+
+---
+
+## Tagline Formulas That Work
+
+### Formula 1: "[Category] for [audience]"
+
+The simplest and most effective pattern. States what the product is and who it serves.
+
+- "Payment infrastructure for the internet" (Stripe)
+- "Application monitoring for developers" (Sentry)
+- "The database for modern applications" (MongoDB)
+
+**When to use:** When the name is abstract or metaphorical and needs grounding.
+
+### Formula 2: "[Verb] your [noun]"
+
+Action-oriented. Tells the user what they'll do with the product.
+
+- "Ship your code with confidence"
+- "Monitor your infrastructure"
+- "Organize your second brain"
+
+**When to use:** When the product's primary action is its selling point.
+
+### Formula 3: "The [adjective] way to [action]"
+
+Positions the product as an improvement over existing alternatives.
+
+- "The fastest way to build web apps"
+- "The simplest way to manage infrastructure"
+- "The modern way to handle payments"
+
+**When to use:** When the product's differentiator is speed, simplicity, or modernity. Careful: "modern" and "simple" are overused — be specific about what makes your approach different.
+
+### Formula 4: "[Verb]. [Verb]. [Verb]."
+
+Three-word action sequences that capture the workflow.
+
+- "Develop. Preview. Ship." (Vercel)
+- "Build. Test. Deploy."
+- "Write. Collaborate. Publish."
+
+**When to use:** When the product's value is a streamlined workflow.
+
+### Formula 5: One concrete statement
+
+A single declarative sentence that captures the product's essence.
+
+- "Your connected workspace" (Notion)
+- "Where work happens" (Slack — original tagline)
+- "Code faster with AI"
+
+**When to use:** When simplicity and confidence are the brand's character.
+
+---
+
+## Tagline Anti-Patterns
+
+### Too long
+
+If the tagline needs a second line, it's not a tagline — it's a description. Maximum: 8-10 words.
+
+**Bad:** "The all-in-one platform for building, deploying, and managing modern web applications at scale"
+**Better:** "Deploy modern web apps"
+
+### Too generic
+
+If you can swap in any competitor's name and the tagline still works, it says nothing.
+
+**Bad:** "Solutions for modern teams" (this could be literally any B2B product)
+**Bad:** "Built for the future" (meaningless)
+**Bad:** "Empowering innovation" (corporate noise)
+
+### Restating the name
+
+The tagline should add information, not repeat what the name already communicates.
+
+**Bad:** "Sentry — Watching over your code" (the name already says "watching")
+**Better:** "Sentry — Application monitoring for developers" (adds audience + category)
+
+### Buzzword stacking
+
+Taglines that combine trending terms without substance.
+
+**Bad:** "AI-powered cloud-native solutions for digital transformation"
+**Better:** Pick ONE concrete thing the product does and say that.
+
+---
+
+## How Name + Tagline Should Complement
+
+The name and tagline should cover different ground:
+
+| Name provides | Tagline provides |
+| ------------- | ---------------- |
+| Metaphor / image | Category / function |
+| Personality / tone | Audience / use case |
+| Memorability | Clarity |
+| Emotional connection | Rational understanding |
+
+**The test:** Read the name alone. Then read the tagline alone. Each should make sense independently, but together they should tell a more complete story than either does alone.
+
+---
+
+## The Billboard Test
+
+Read the name + tagline as if it were on a billboard you're driving past at 60mph. You get about 3 seconds.
+
+- Can you read the entire thing?
+- Do you understand what the product does?
+- Would you remember it 10 minutes later?
+
+If the answer to any of these is "no," the tagline is too long, too vague, or too complex.
+
+---
+
+## Tagline vs. Slogan vs. Descriptor
+
+These are different things:
+
+| Type | What it is | Example |
+| ---- | ---------- | ------- |
+| **Tagline** | Permanent brand line that sits next to the name | "Payment infrastructure for the internet" |
+| **Slogan** | Campaign-specific, changes over time | "Move fast, break nothing" |
+| **Descriptor** | Literal category label, no creativity | "Cloud monitoring service" |
+
+A good tagline sits between descriptor (too boring) and slogan (too campaign-specific). It should last 3-5 years minimum.


### PR DESCRIPTION
## Summary

- Adds `taglines.md` covering tagline formulas, anti-patterns, name+tagline complementarity, the billboard test, and tagline vs. slogan vs. descriptor distinctions
- Wires into SKILL.md Step 7 — suggests taglines alongside finalists
- Adds entry to SKILL.md Reference Files table

Closes #134