### PR TITLE
Add WordPress trademark rules to naming guidance, issue : #152

### DIFF
--- a/anti-patterns.md
+++ b/anti-patterns.md
@@ -33,9 +33,9 @@ Framework adapted from professional naming agencies. If a name has any of these,
 
 Driven by fear of standing out. "WordPress Site Monitor" is a description, not a name. "Cloud-Based Team Collaboration Platform" is a sentence, not a brand.
 
- **WordPress Trademark:**  Using **"WordPress"** inside a product name is not only generic — it can violate the WordPress Foundation trademark policy.  
- - **Acceptable pattern:** *"[Product Name] for WordPress"* (descriptor).  
- - **Risky / disallowed pattern:** *"WordPressBackup", "WordPressMonitor", "WPWordPressTool".*
+ **WordPress Trademark:**  Using **"WordPress"** inside a product name is not only generic -it can violate the WordPress Foundation trademark policy.  
+- **Acceptable pattern:** *"[Product Name] for WordPress"* (descriptor).  
+- **Risky / disallowed pattern:** *"WordPressBackup", "WordPressMonitor", "WPWordPressTool".*
 
 **Why it happens:** Stakeholders feel safe with descriptions because they're immediately clear. But clarity without memorability is useless — people understand what the product does for 5 seconds, then forget its name forever.
 

--- a/anti-patterns.md
+++ b/anti-patterns.md
@@ -33,10 +33,9 @@ Framework adapted from professional naming agencies. If a name has any of these,
 
 Driven by fear of standing out. "WordPress Site Monitor" is a description, not a name. "Cloud-Based Team Collaboration Platform" is a sentence, not a brand.
 
-> **Trademark reality check:**  
-> Using **"WordPress" inside a product name is not only generic — it can violate the WordPress Foundation trademark policy.  
-> Acceptable pattern: *"[Product Name] for WordPress"* (descriptor).  
-> Risky / disallowed pattern: *"WordPressBackup", "WordPressMonitor", "WPWordPressTool".*
+ >**Trademark reality check:**  Using **"WordPress"** inside a product name is not only generic — it can violate the WordPress Foundation trademark policy.  
+ >**Acceptable pattern:** *"[Product Name] for WordPress"* (descriptor).  
+ >**Risky / disallowed pattern:** *"WordPressBackup", "WordPressMonitor", "WPWordPressTool".*
 
 **Why it happens:** Stakeholders feel safe with descriptions because they're immediately clear. But clarity without memorability is useless — people understand what the product does for 5 seconds, then forget its name forever.
 

--- a/anti-patterns.md
+++ b/anti-patterns.md
@@ -33,9 +33,9 @@ Framework adapted from professional naming agencies. If a name has any of these,
 
 Driven by fear of standing out. "WordPress Site Monitor" is a description, not a name. "Cloud-Based Team Collaboration Platform" is a sentence, not a brand.
 
- >**Trademark reality check:**  Using **"WordPress"** inside a product name is not only generic — it can violate the WordPress Foundation trademark policy.  
- >**Acceptable pattern:** *"[Product Name] for WordPress"* (descriptor).  
- >**Risky / disallowed pattern:** *"WordPressBackup", "WordPressMonitor", "WPWordPressTool".*
+ **WordPress Trademark:**  Using **"WordPress"** inside a product name is not only generic — it can violate the WordPress Foundation trademark policy.  
+ - **Acceptable pattern:** *"[Product Name] for WordPress"* (descriptor).  
+ - **Risky / disallowed pattern:** *"WordPressBackup", "WordPressMonitor", "WPWordPressTool".*
 
 **Why it happens:** Stakeholders feel safe with descriptions because they're immediately clear. But clarity without memorability is useless — people understand what the product does for 5 seconds, then forget its name forever.
 

--- a/anti-patterns.md
+++ b/anti-patterns.md
@@ -33,6 +33,11 @@ Framework adapted from professional naming agencies. If a name has any of these,
 
 Driven by fear of standing out. "WordPress Site Monitor" is a description, not a name. "Cloud-Based Team Collaboration Platform" is a sentence, not a brand.
 
+> **Trademark reality check:**  
+> Using **"WordPress" inside a product name is not only generic — it can violate the WordPress Foundation trademark policy.  
+> Acceptable pattern: *"[Product Name] for WordPress"* (descriptor).  
+> Risky / disallowed pattern: *"WordPressBackup", "WordPressMonitor", "WPWordPressTool".*
+
 **Why it happens:** Stakeholders feel safe with descriptions because they're immediately clear. But clarity without memorability is useless — people understand what the product does for 5 seconds, then forget its name forever.
 
 **The fix:** Use the description as your tagline, not your name. The name creates recall; the tagline creates clarity.

--- a/anti-patterns.md
+++ b/anti-patterns.md
@@ -33,8 +33,8 @@ Framework adapted from professional naming agencies. If a name has any of these,
 
 Driven by fear of standing out. "WordPress Site Monitor" is a description, not a name. "Cloud-Based Team Collaboration Platform" is a sentence, not a brand.
 
- **WordPress Trademark:**  Using **"WordPress"** inside a product name is not only generic -it can violate the WordPress Foundation trademark policy.  
-- **Acceptable pattern:** *"[Product Name] for WordPress"* (descriptor).  
+ **WordPress Trademark:**  Using **"WordPress"** inside a product name is not only generic — it can violate the WordPress Foundation trademark policy.
+- **Acceptable pattern:** *"[Product Name] for WordPress"* (descriptor).
 - **Risky / disallowed pattern:** *"WordPressBackup", "WordPressMonitor", "WPWordPressTool".*
 
 **Why it happens:** Stakeholders feel safe with descriptions because they're immediately clear. But clarity without memorability is useless — people understand what the product does for 5 seconds, then forget its name forever.

--- a/availability.md
+++ b/availability.md
@@ -135,7 +135,7 @@ The WordPress Foundation enforces trademark rules that affect plugin and theme n
 - **"WordPress" cannot be used** in commercial product names (plugin, theme, SaaS)
 - **"WP" is allowed** but discouraged — signals commodity, not premium
 - **"for WordPress" is acceptable** as a descriptor, not a name component
-- **Check:** WordPress Trademark Policy
+- **Check:** [WordPress Trademark Policy](https://wordpressfoundation.org/trademark-policy/)
 
 ---
 

--- a/availability.md
+++ b/availability.md
@@ -132,8 +132,8 @@ For serious products, do a basic trademark search. You don't need a lawyer for i
 
 The WordPress Foundation enforces trademark rules that affect plugin and theme naming:
 
-- **WordPress cannot be used** in commercial product names (plugin, theme, SaaS)
-- **WP is allowed** but discouraged — signals commodity, not premium
+- **"WordPress" cannot be used** in commercial product names (plugin, theme, SaaS)
+- **"WP" is allowed** but discouraged — signals commodity, not premium
 - **"for WordPress" is acceptable** as a descriptor, not a name component
 - **Check:** WordPress Trademark Policy
 

--- a/availability.md
+++ b/availability.md
@@ -128,6 +128,17 @@ For serious products, do a basic trademark search. You don't need a lawyer for i
 
 ---
 
+### WordPress Naming Restrictions
+
+The WordPress Foundation enforces trademark rules that affect plugin and theme naming:
+
+**WordPress cannot be used** in commercial product names (plugin, theme, SaaS)
+**WP is allowed** but discouraged — signals commodity, not premium
+**"for WordPress" is acceptable** as a descriptor, not a name component
+**Check:** WordPress Trademark Policy
+
+---
+
 ## Availability Decision Framework
 
 Not every platform needs to be available. Prioritize based on your product type:

--- a/availability.md
+++ b/availability.md
@@ -132,10 +132,10 @@ For serious products, do a basic trademark search. You don't need a lawyer for i
 
 The WordPress Foundation enforces trademark rules that affect plugin and theme naming:
 
-**WordPress cannot be used** in commercial product names (plugin, theme, SaaS)
-**WP is allowed** but discouraged — signals commodity, not premium
-**"for WordPress" is acceptable** as a descriptor, not a name component
-**Check:** WordPress Trademark Policy
+- **WordPress cannot be used** in commercial product names (plugin, theme, SaaS)
+- **WP is allowed** but discouraged — signals commodity, not premium
+- **"for WordPress" is acceptable** as a descriptor, not a name component
+- **Check:** WordPress Trademark Policy
 
 ---
 


### PR DESCRIPTION
## What this changes

Adds a trademark note warning against using "WordPress" inside product names.

This expands the "Boring Descriptive Names" anti-pattern by showing that overly descriptive naming can introduce not only strategic weakness (lack of memorability) but also legal / trademark risk.

Also adds a short WordPress naming restrictions section in the availability guidance to reinforce correct usage patterns such as "[Product Name] for WordPress".

## Which files

anti-patterns.md
availability.md

## Checklist

- [ x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] Cross-references to other files are updated (if applicable)
- [ ] New content uses real product names as examples (not hypothetical)
- [ ] Case studies include source links

Closes #152
